### PR TITLE
Add semicolons after latest pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ var concat = require('gulp-concat');
 gulp.task('scripts', function() {
   gulp.src('./lib/*.js')
     .pipe(concat('all.js'))
-    .pipe(gulp.dest('./dist/'))
+    .pipe(gulp.dest('./dist/'));
 });
 ```
 
@@ -38,7 +38,7 @@ var concat = require('gulp-concat');
 gulp.task('scripts', function() {
   gulp.src(['./lib/file3.js', './lib/file1.js', './lib/file2.js'])
     .pipe(concat('all.js'))
-    .pipe(gulp.dest('./dist/'))
+    .pipe(gulp.dest('./dist/'));
 });
 ```
 
@@ -58,7 +58,7 @@ var concat = require('gulp-concat');
 gulp.task('scripts', function() {
   gulp.src(['./lib/file3.js', './lib/file1.js', './lib/file2.js'])
     .pipe(concat({ path: 'new.js', stat: { mode: 0666 }}))
-    .pipe(gulp.dest('./dist'))
+    .pipe(gulp.dest('./dist'));
 });
 ```
 


### PR DESCRIPTION
Seems like was forgotten some semicolons after latest pipes in README.md examples.