### PR TITLE
Use through2 instead of through

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-.DS_Store
-*.log
-node_modules
-build
-*.node
-components

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
 language: node_js
 node_js:
+  - iojs
+  - "0.12"
   - "0.10"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![status](https://secure.travis-ci.org/wearefractal/gulp-concat.png?branch=master)
+![status](https://secure.travis-ci.org/wearefractal/gulp-concat.svg?branch=master)
 
 ## Information
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "concat-with-sourcemaps": "^1.0.0",
     "gulp-util": "^3.0.1",
-    "through": "^2.3.4"
+    "through2": "^0.6.3"
   },
   "devDependencies": {
     "gulp": "^3.8.7",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "gulp-concat",
   "description": "Concatenates files",
   "version": "2.4.3",
-  "homepage": "http://github.com/wearefractal/gulp-concat",
-  "repository": "git://github.com/wearefractal/gulp-concat.git",
+  "repository": "wearefractal/gulp-concat",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
   "files": [
     "index.js"
@@ -22,13 +21,13 @@
     "istanbul": "^0.3.2",
     "mocha": "^2.0.1",
     "mocha-lcov-reporter": "0.0.1",
-    "should": "^4.3.0",
+    "should": "^5.0.0",
     "stream-array": "^1.0.1",
     "stream-assert": "^2.0.1"
   },
   "scripts": {
     "test": "mocha",
-    "coverage": "istanbul cover _mocha -- -R spec"
+    "coverage": "istanbul cover _mocha"
   },
   "engineStrict": true,
   "engines": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "homepage": "http://github.com/wearefractal/gulp-concat",
   "repository": "git://github.com/wearefractal/gulp-concat.git",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
-  "main": "./index.js",
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "gulpplugin"
   ],

--- a/test/main.js
+++ b/test/main.js
@@ -39,6 +39,7 @@ describe('gulp-concat', function() {
     it('should concat one file', function (done) {
       test('wadap')
         .pipe(concat('test.js'))
+        .pipe(assert.length(1))
         .pipe(assert.first(function (d) { d.contents.toString().should.eql('wadap'); }))
         .pipe(assert.end(done));
     });
@@ -54,6 +55,7 @@ describe('gulp-concat', function() {
     it('should concatinate buffers', function (done) {
       test([65, 66], [67, 68], [69, 70])
         .pipe(concat('test.js'))
+        .pipe(assert.length(1))
         .pipe(assert.first(function (d) { d.contents.toString().should.eql('AB\nCD\nEF'); }))
         .pipe(assert.end(done));
     });
@@ -61,6 +63,7 @@ describe('gulp-concat', function() {
     it('should preserve mode from files', function (done) {
       test('wadaup')
         .pipe(concat('test.js'))
+        .pipe(assert.length(1))
         .pipe(assert.first(function (d) { d.stat.mode.should.eql(0666); }))
         .pipe(assert.end(done));
     });
@@ -68,6 +71,7 @@ describe('gulp-concat', function() {
     it('should take path from first file', function (done) {
       test('wadap', 'doe')
         .pipe(concat('test.js'))
+        .pipe(assert.length(1))
         .pipe(assert.first(function (newFile) {
           var newFilePath = path.resolve(newFile.path);
           var expectedFilePath = path.resolve('/home/contra/test/test.js');
@@ -79,6 +83,7 @@ describe('gulp-concat', function() {
     it('should preserve relative path from files', function (done) {
       test('wadap', 'doe')
         .pipe(concat('test.js'))
+        .pipe(assert.length(1))
         .pipe(assert.first(function (d) { d.relative.should.eql('test.js'); }))
         .pipe(assert.end(done));
     });
@@ -87,6 +92,7 @@ describe('gulp-concat', function() {
       gulp.src(fixtures('*'))
         .pipe(sourcemaps.init())
         .pipe(concat('all.js'))
+        .pipe(assert.length(1))
         .pipe(assert.first(function (d) {
           d.sourceMap.sources.should.have.length(2);
           d.sourceMap.file.should.eql('all.js');
@@ -104,6 +110,7 @@ describe('gulp-concat', function() {
       it('should support newLine', function (done) {
         test('wadap', 'doe')
           .pipe(concat('test.js', {newLine: '\r\n'}))
+          .pipe(assert.length(1))
           .pipe(assert.first(function (d) { d.contents.toString().should.eql('wadap\r\ndoe'); }))
           .pipe(assert.end(done));
       })
@@ -111,6 +118,7 @@ describe('gulp-concat', function() {
       it('should support empty newLine', function (done) {
         test('wadap', 'doe')
           .pipe(concat('test.js', {newLine: ''}))
+          .pipe(assert.length(1))
           .pipe(assert.first(function (d) { d.contents.toString().should.eql('wadapdoe'); }))
           .pipe(assert.end(done));
       })
@@ -126,6 +134,7 @@ describe('gulp-concat', function() {
       it('should create file based on path property', function (done) {
         test('wadap')
           .pipe(concat({path: 'new.txt'}))
+          .pipe(assert.length(1))
           .pipe(assert.first(function (d) { d.path.should.eql('new.txt'); }))
           .pipe(assert.end(done));
       });
@@ -133,6 +142,7 @@ describe('gulp-concat', function() {
       it('should calculate relative path from cwd and path in arguments', function (done) {
         test('wadap')
           .pipe(concat({cwd: '/home/contra', path: '/home/contra/test/new.txt'}))
+          .pipe(assert.length(1))
           .pipe(assert.first(function (d) { d.relative.should.eql('test/new.txt'); }))
           .pipe(assert.end(done));
       });


### PR DESCRIPTION
* I replaced [through](https://github.com/dominictarr/through) with [through2](https://github.com/rvagg/through2). through2 uses Stream2.
* I updated .travis.yml.
  * I added `sudo: false` to use container-based infrastructure.
  * I added `iojs` and `0.12` to the Node versions that Travis CI tests against.
* I added `files` field to the [package.json](https://github.com/wearefractal/gulp-concat/blob/master/package.json) and removed [.npmignore](https://github.com/wearefractal/gulp-concat/blob/2b7672e7a4d4594cd9d00cf8ec28b1c8bdbe6534/.npmignore).
  * Whitelist is more consistent than blacklist.
* I updated image format of the Travis CI badge from PNG to SVG. SVG badges look beautiful on retina displays.

| png ver. | svg ver. |
| --- | --- |
| ![status](https://secure.travis-ci.org/wearefractal/gulp-concat.png?branch=master) | ![status](https://secure.travis-ci.org/wearefractal/gulp-concat.svg?branch=master) |
