### PR TITLE
Remove engineStrict

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "test": "mocha",
     "coverage": "istanbul cover _mocha"
   },
-  "engineStrict": true,
   "engines": {
     "node": ">= 0.10"
   },


### PR DESCRIPTION
Is it really necessary to have engineStrict to be set? It's throwing warnings in npm v2.6.0

Removing this line to prevent this error message:
```
npm WARN engineStrict Per-package engineStrict (found in package.json for gulp-concat)
```